### PR TITLE
ci: force node version as a workaround

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Use Node.js >= 18
+      - name: Use Node.js 18
         uses: actions/setup-node@v3
         with:
-          node-version: '>= 18'
+          node-version: '18.15'
 
       - name: Cache node modules
         uses: actions/cache@v3


### PR DESCRIPTION
Related issue: https://github.com/ZJONSSON/node-unzipper/issues/271