### PR TITLE
feat(portal): migrate to Angular standalone APIs

### DIFF
--- a/packages/portal/src/app/app.component.ts
+++ b/packages/portal/src/app/app.component.ts
@@ -1,7 +1,6 @@
 import { Component } from "@angular/core";
 import { MatToolbarModule } from "@angular/material/toolbar";
 import { RouterModule } from "@angular/router";
-import { AppModule } from "./app.module";
 import { MainNavComponent } from "./shared/main-nav/main-nav.component";
 
 @Component({
@@ -9,6 +8,6 @@ import { MainNavComponent } from "./shared/main-nav/main-nav.component";
   templateUrl: "./app.component.html",
   styleUrls: ["./app.component.scss"],
   standalone: true,
-  imports: [RouterModule, MainNavComponent, AppModule, MatToolbarModule],
+  imports: [RouterModule, MainNavComponent, MatToolbarModule],
 })
 export class AppComponent {}

--- a/packages/portal/src/app/app.config.ts
+++ b/packages/portal/src/app/app.config.ts
@@ -4,6 +4,7 @@ import { provideAnimations } from "@angular/platform-browser/animations";
 import { provideRouter } from "@angular/router";
 import { ROUTES } from "./app-routing";
 import { provideApollo } from "./core/apollo/provide-apollo";
+import { provideUser } from "./core/user/provide-user";
 
 export const appConfig: ApplicationConfig = {
   providers: [
@@ -11,5 +12,6 @@ export const appConfig: ApplicationConfig = {
     provideRouter(ROUTES),
     provideHttpClient(),
     provideAnimations(),
+    provideUser(),
   ],
 };

--- a/packages/portal/src/app/app.config.ts
+++ b/packages/portal/src/app/app.config.ts
@@ -2,38 +2,14 @@ import { provideHttpClient } from "@angular/common/http";
 import { ApplicationConfig } from "@angular/core";
 import { provideAnimations } from "@angular/platform-browser/animations";
 import { provideRouter } from "@angular/router";
-import { InMemoryCache } from "@apollo/client/core";
-import { Apollo, APOLLO_OPTIONS } from "apollo-angular";
-import { HttpLink } from "apollo-angular/http";
-import { environment } from "../environments/environment";
 import { ROUTES } from "./app-routing";
-
-const uri = () => {
-  if (!environment.production && environment.isCodespaces) {
-    return environment.strapiGraphQlUriInCodespace;
-  }
-  return environment.strapiGraphQlUriFallback;
-};
-
-export function createApollo(httpLink: HttpLink) {
-  return {
-    link: httpLink.create({
-      uri: uri(),
-    }),
-    cache: new InMemoryCache(),
-  };
-}
+import { provideApollo } from "./core/apollo/provide-apollo";
 
 export const appConfig: ApplicationConfig = {
   providers: [
-    Apollo,
+    provideApollo(),
     provideRouter(ROUTES),
     provideHttpClient(),
-    {
-      provide: APOLLO_OPTIONS,
-      useFactory: createApollo,
-      deps: [HttpLink],
-    },
     provideAnimations(),
   ],
 };

--- a/packages/portal/src/app/app.config.ts
+++ b/packages/portal/src/app/app.config.ts
@@ -1,0 +1,39 @@
+import { provideHttpClient } from "@angular/common/http";
+import { ApplicationConfig } from "@angular/core";
+import { provideAnimations } from "@angular/platform-browser/animations";
+import { provideRouter } from "@angular/router";
+import { InMemoryCache } from "@apollo/client/core";
+import { Apollo, APOLLO_OPTIONS } from "apollo-angular";
+import { HttpLink } from "apollo-angular/http";
+import { environment } from "../environments/environment";
+import { ROUTES } from "./app-routing";
+
+const uri = () => {
+  if (!environment.production && environment.isCodespaces) {
+    return environment.strapiGraphQlUriInCodespace;
+  }
+  return environment.strapiGraphQlUriFallback;
+};
+
+export function createApollo(httpLink: HttpLink) {
+  return {
+    link: httpLink.create({
+      uri: uri(),
+    }),
+    cache: new InMemoryCache(),
+  };
+}
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    Apollo,
+    provideRouter(ROUTES),
+    provideHttpClient(),
+    {
+      provide: APOLLO_OPTIONS,
+      useFactory: createApollo,
+      deps: [HttpLink],
+    },
+    provideAnimations(),
+  ],
+};

--- a/packages/portal/src/app/app.module.ts
+++ b/packages/portal/src/app/app.module.ts
@@ -1,4 +1,0 @@
-import { NgModule } from "@angular/core";
-
-@NgModule()
-export class AppModule {}

--- a/packages/portal/src/app/core/apollo/provide-apollo.ts
+++ b/packages/portal/src/app/core/apollo/provide-apollo.ts
@@ -1,0 +1,31 @@
+import { EnvironmentProviders, FactoryProvider, makeEnvironmentProviders } from "@angular/core";
+import { ApolloClientOptions, InMemoryCache, NormalizedCacheObject } from "@apollo/client/core";
+import { Apollo, APOLLO_OPTIONS } from "apollo-angular";
+import { HttpLink } from "apollo-angular/http";
+import { environment } from "../../../environments/environment";
+
+function createApollo(httpLink: HttpLink): ApolloClientOptions<NormalizedCacheObject> {
+  return {
+    link: httpLink.create({
+      uri: uri(),
+    }),
+    cache: new InMemoryCache(),
+  };
+}
+
+const uri = () => {
+  if (!environment.production && environment.isCodespaces) {
+    return environment.strapiGraphQlUriInCodespace;
+  }
+  return environment.strapiGraphQlUriFallback;
+};
+
+export function provideApollo(): EnvironmentProviders {
+  const apolloOptionsProvider: FactoryProvider = {
+    provide: APOLLO_OPTIONS,
+    useFactory: createApollo,
+    deps: [HttpLink],
+  };
+
+  return makeEnvironmentProviders([apolloOptionsProvider, Apollo]);
+}

--- a/packages/portal/src/app/core/user/provide-user.ts
+++ b/packages/portal/src/app/core/user/provide-user.ts
@@ -1,0 +1,17 @@
+import { APP_INITIALIZER, EnvironmentProviders, FactoryProvider, makeEnvironmentProviders } from "@angular/core";
+import { UserService } from "../../shared/user/user.service";
+
+function createInitializeUser(userService: UserService): () => Promise<User> {
+  return () => userService.fetchAndStoreUserSession();
+}
+
+export function provideUser(): EnvironmentProviders {
+  const userInitializerProvider: FactoryProvider = {
+    provide: APP_INITIALIZER,
+    useFactory: createInitializeUser,
+    deps: [UserService],
+    multi: true,
+  };
+
+  return makeEnvironmentProviders([userInitializerProvider]);
+}

--- a/packages/portal/src/main.ts
+++ b/packages/portal/src/main.ts
@@ -1,49 +1,15 @@
 import { enableProdMode } from "@angular/core";
 import { bootstrapApplication } from "@angular/platform-browser";
-import { provideAnimations } from "@angular/platform-browser/animations";
-import { provideRouter } from "@angular/router";
-import { ROUTES } from "./app/app-routing";
-import { provideHttpClient } from "@angular/common/http";
 import { AppComponent } from "./app/app.component";
+import { appConfig } from "./app/app.config";
 import { UserService } from "./app/shared/user/user.service";
 import { environment } from "./environments/environment";
-import { APOLLO_OPTIONS, Apollo } from 'apollo-angular';
-import { HttpLink } from 'apollo-angular/http';
-import { InMemoryCache } from '@apollo/client/core';
-
-const uri = () => {
-  if (!environment.production && environment.isCodespaces) {
-    return environment.strapiGraphQlUriInCodespace;
-  }
-  return environment.strapiGraphQlUriFallback;
-};
-
-export function createApollo(httpLink: HttpLink) {
-  return {
-    link: httpLink.create({
-      uri: uri(),
-    }),
-    cache: new InMemoryCache(),
-  };
-}
 
 if (environment.production) {
   enableProdMode();
 }
 
-bootstrapApplication(AppComponent, {
-  providers: [
-    Apollo,
-    provideRouter(ROUTES),
-    provideHttpClient(),
-    {
-      provide: APOLLO_OPTIONS,
-      useFactory: createApollo,
-      deps: [HttpLink],
-    },
-    provideAnimations(),
-  ],
-}).then(async app => {
+bootstrapApplication(AppComponent, appConfig).then(async app => {
   const userService = app.injector.get(UserService);
   await userService.fetchAndStoreUserSession();
   console.log("Application is ready!");

--- a/packages/portal/src/main.ts
+++ b/packages/portal/src/main.ts
@@ -1,10 +1,6 @@
 import { bootstrapApplication } from "@angular/platform-browser";
 import { AppComponent } from "./app/app.component";
 import { appConfig } from "./app/app.config";
-import { UserService } from "./app/shared/user/user.service";
 
-bootstrapApplication(AppComponent, appConfig).then(async app => {
-  const userService = app.injector.get(UserService);
-  await userService.fetchAndStoreUserSession();
-  console.log("Application is ready!");
-});
+bootstrapApplication(AppComponent, appConfig)
+  .then(() => console.log("Application is ready!"));

--- a/packages/portal/src/main.ts
+++ b/packages/portal/src/main.ts
@@ -1,13 +1,7 @@
-import { enableProdMode } from "@angular/core";
 import { bootstrapApplication } from "@angular/platform-browser";
 import { AppComponent } from "./app/app.component";
 import { appConfig } from "./app/app.config";
 import { UserService } from "./app/shared/user/user.service";
-import { environment } from "./environments/environment";
-
-if (environment.production) {
-  enableProdMode();
-}
 
 bootstrapApplication(AppComponent, appConfig).then(async app => {
   const userService = app.injector.get(UserService);

--- a/packages/portal/src/main.ts
+++ b/packages/portal/src/main.ts
@@ -3,7 +3,7 @@ import { bootstrapApplication } from "@angular/platform-browser";
 import { provideAnimations } from "@angular/platform-browser/animations";
 import { provideRouter } from "@angular/router";
 import { ROUTES } from "./app/app-routing";
-import { HttpClientModule } from "@angular/common/http";
+import { provideHttpClient } from "@angular/common/http";
 import { AppComponent } from "./app/app.component";
 import { UserService } from "./app/shared/user/user.service";
 import { environment } from "./environments/environment";
@@ -35,9 +35,8 @@ bootstrapApplication(AppComponent, {
   providers: [
     Apollo,
     provideRouter(ROUTES),
-    importProvidersFrom(
-      HttpClientModule,
-    ),
+    provideHttpClient(),
+    importProvidersFrom(),
     {
       provide: APOLLO_OPTIONS,
       useFactory: createApollo,

--- a/packages/portal/src/main.ts
+++ b/packages/portal/src/main.ts
@@ -3,4 +3,5 @@ import { AppComponent } from "./app/app.component";
 import { appConfig } from "./app/app.config";
 
 bootstrapApplication(AppComponent, appConfig)
-  .then(() => console.log("Application is ready!"));
+  .then(() => console.log("Application is ready!"))
+  .catch(error => console.error(error));

--- a/packages/portal/src/main.ts
+++ b/packages/portal/src/main.ts
@@ -1,4 +1,4 @@
-import { enableProdMode, importProvidersFrom } from "@angular/core";
+import { enableProdMode } from "@angular/core";
 import { bootstrapApplication } from "@angular/platform-browser";
 import { provideAnimations } from "@angular/platform-browser/animations";
 import { provideRouter } from "@angular/router";
@@ -36,7 +36,6 @@ bootstrapApplication(AppComponent, {
     Apollo,
     provideRouter(ROUTES),
     provideHttpClient(),
-    importProvidersFrom(),
     {
       provide: APOLLO_OPTIONS,
       useFactory: createApollo,

--- a/packages/portal/src/main.ts
+++ b/packages/portal/src/main.ts
@@ -1,7 +1,7 @@
 import { enableProdMode, importProvidersFrom } from "@angular/core";
 import { bootstrapApplication } from "@angular/platform-browser";
 import { provideAnimations } from "@angular/platform-browser/animations";
-import { RouterModule } from "@angular/router";
+import { provideRouter } from "@angular/router";
 import { ROUTES } from "./app/app-routing";
 import { HttpClientModule } from "@angular/common/http";
 import { AppComponent } from "./app/app.component";
@@ -34,8 +34,8 @@ if (environment.production) {
 bootstrapApplication(AppComponent, {
   providers: [
     Apollo,
+    provideRouter(ROUTES),
     importProvidersFrom(
-      RouterModule.forRoot(ROUTES),
       HttpClientModule,
     ),
     {


### PR DESCRIPTION
Closes #224.

# Features
- Log boostrap errors to the browser console

# Refactors
- Use standalone HTTP providers
- Use standalone Router providers
- Extract standalone Apollo provider
- Extract standalone user provider
- Extract application config to align with defaults scaffolded by Angular CLI
- Remove unused `AppModule`
- Remove unnecessary `enableProdMode`