### PR TITLE
test(portal): use Angular CLI's Jest builder

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,29 +34,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@angular-builders/jest": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/@angular-builders/jest/-/jest-16.0.0.tgz",
-      "integrity": "sha512-FyKrZLhbgeyqrwmh9oSJk8VL4cZ7qgwYKnn2KM0RwWjel5rxefGCNO+JL7qr4x07wvKXT2LLziO1OwsOTUjH1g==",
-      "dev": true,
-      "dependencies": {
-        "@angular-devkit/architect": ">=0.1600.0 < 0.1700.0",
-        "@angular-devkit/core": "^16.0.0",
-        "jest-preset-angular": "13.1.1",
-        "lodash": "^4.17.15",
-        "tsconfig-paths": "^4.1.0"
-      },
-      "engines": {
-        "node": "^14.20.0 || ^16.13.0 || >=18.10.0"
-      },
-      "peerDependencies": {
-        "@angular-devkit/build-angular": "^16.0.0",
-        "@angular/compiler-cli": "^16.0.0",
-        "@angular/core": "^16.0.0",
-        "@angular/platform-browser-dynamic": "^16.0.0",
-        "jest": ">=29"
-      }
-    },
     "node_modules/@angular-devkit/architect": {
       "version": "0.1600.5",
       "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1600.5.tgz",
@@ -11239,6 +11216,8 @@
       "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-20.0.1.tgz",
       "integrity": "sha512-d0r18sZPmMQr1eG35u12FZfhIXNrnsPU/g5wvRKCUf/tOGilKKwYMYGqh33BNR6ba+2gkHw1EUiHoN3mn7E5IQ==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "@types/tough-cookie": "*",
@@ -11541,7 +11520,9 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.2.tgz",
       "integrity": "sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/@types/triple-beam": {
       "version": "1.3.2",
@@ -12157,6 +12138,8 @@
       "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-7.0.1.tgz",
       "integrity": "sha512-umOSDSDrfHbTNPuNpC2NSnnA3LUrqpevPb4T9jRx4MagXNS0rs+gwiTcAvqCRmsD6utzsrzNt+ebm00SNWiC3Q==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "acorn": "^8.1.0",
         "acorn-walk": "^8.0.2"
@@ -14174,18 +14157,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/bs-logger": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
-      "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
-      "dev": true,
-      "dependencies": {
-        "fast-json-stable-stringify": "2.x"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/bser": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
@@ -15925,13 +15896,17 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
       "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/cssstyle": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
       "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "cssom": "~0.3.6"
       },
@@ -15943,7 +15918,9 @@
       "version": "0.3.8",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
       "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/csstype": {
       "version": "3.1.2",
@@ -15969,6 +15946,8 @@
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-3.0.2.tgz",
       "integrity": "sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "abab": "^2.0.6",
         "whatwg-mimetype": "^3.0.0",
@@ -16035,7 +16014,9 @@
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
       "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/decode-named-character-reference": {
       "version": "1.0.2",
@@ -16777,6 +16758,8 @@
       "resolved": "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz",
       "integrity": "sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "webidl-conversions": "^7.0.0"
       },
@@ -17725,6 +17708,8 @@
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.0.0.tgz",
       "integrity": "sha512-mmHKys/C8BFUGI+MAWNcSYoORYLMdPzjrknd2Vc+bUsjN5bXcr8EhrNB+UTqfL1y3I9c4fw2ihgtMPQLBRiQxw==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "esprima": "^4.0.1",
         "estraverse": "^5.2.0",
@@ -17747,6 +17732,8 @@
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -17756,6 +17743,8 @@
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2"
@@ -17769,6 +17758,8 @@
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
       "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "deep-is": "~0.1.3",
         "fast-levenshtein": "~2.0.6",
@@ -17786,6 +17777,8 @@
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 0.8.0"
       }
@@ -17796,6 +17789,7 @@
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true,
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -17805,6 +17799,8 @@
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "prelude-ls": "~1.1.2"
       },
@@ -21221,6 +21217,8 @@
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
       "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "whatwg-encoding": "^2.0.0"
       },
@@ -22336,7 +22334,9 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/is-regex": {
       "version": "1.1.4",
@@ -23005,6 +23005,8 @@
       "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-29.5.0.tgz",
       "integrity": "sha512-/KG8yEK4aN8ak56yFVdqFDzKNHgF4BAymCx2LbPNPsUshUlfAl0eX402Xm1pt+eoG9SLZEUVifqXtX8SK74KCw==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@jest/environment": "^29.5.0",
         "@jest/fake-timers": "^29.5.0",
@@ -23155,34 +23157,6 @@
         "jest-resolve": {
           "optional": true
         }
-      }
-    },
-    "node_modules/jest-preset-angular": {
-      "version": "13.1.1",
-      "resolved": "https://registry.npmjs.org/jest-preset-angular/-/jest-preset-angular-13.1.1.tgz",
-      "integrity": "sha512-X8i7icKt9U5uhj7YKqdEZm7ZZPvNFRxfBnU+9SALdIkHYJhwtlJ5/MUk9wo4f3lX2smOkIl9LPJUu1APO+11Jg==",
-      "dev": true,
-      "dependencies": {
-        "bs-logger": "^0.2.6",
-        "esbuild-wasm": ">=0.13.8",
-        "jest-environment-jsdom": "^29.0.0",
-        "jest-util": "^29.0.0",
-        "pretty-format": "^29.0.0",
-        "ts-jest": "^29.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || >=16.10.0"
-      },
-      "optionalDependencies": {
-        "esbuild": ">=0.13.8"
-      },
-      "peerDependencies": {
-        "@angular-devkit/build-angular": ">=13.0.0 <17.0.0",
-        "@angular/compiler-cli": ">=13.0.0 <17.0.0",
-        "@angular/core": ">=13.0.0 <17.0.0",
-        "@angular/platform-browser-dynamic": ">=13.0.0 <17.0.0",
-        "jest": "^29.0.0",
-        "typescript": ">=4.4"
       }
     },
     "node_modules/jest-regex-util": {
@@ -23499,6 +23473,8 @@
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-20.0.3.tgz",
       "integrity": "sha512-SYhBvTh89tTfCD/CRdSOm13mOBa42iTaTyfyEWBdKcGdPxPtLFBXuHR8XHb33YNYaP+lLbmSvBTsnoesCNJEsQ==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "abab": "^2.0.6",
         "acorn": "^8.8.1",
@@ -24567,12 +24543,6 @@
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
       "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
-    },
-    "node_modules/lodash.memoize": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
-      "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
-      "dev": true
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -27182,7 +27152,9 @@
       "version": "2.2.5",
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.5.tgz",
       "integrity": "sha512-6xpotnECFy/og7tKSBVmUNft7J3jyXAka4XvG6AUhFWRz+Q/Ljus7znJAA3bxColfQLdS+XsjoodtJfCgeTEFQ==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/nyc": {
       "version": "15.1.0",
@@ -29707,7 +29679,9 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
       "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -31411,6 +31385,8 @@
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
       "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "xmlchars": "^2.2.0"
       },
@@ -33071,7 +33047,9 @@
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/synckit": {
       "version": "0.8.5",
@@ -35681,6 +35659,8 @@
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
       "integrity": "sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "psl": "^1.1.33",
         "punycode": "^2.1.1",
@@ -35764,49 +35744,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/ts-jest": {
-      "version": "29.1.0",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.1.0.tgz",
-      "integrity": "sha512-ZhNr7Z4PcYa+JjMl62ir+zPiNJfXJN6E8hSLnaUKhOgqcn8vb3e537cpkd0FuAfRK3sR1LSqM1MOhliXNgOFPA==",
-      "dev": true,
-      "dependencies": {
-        "bs-logger": "0.x",
-        "fast-json-stable-stringify": "2.x",
-        "jest-util": "^29.0.0",
-        "json5": "^2.2.3",
-        "lodash.memoize": "4.x",
-        "make-error": "1.x",
-        "semver": "7.x",
-        "yargs-parser": "^21.0.1"
-      },
-      "bin": {
-        "ts-jest": "cli.js"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      },
-      "peerDependencies": {
-        "@babel/core": ">=7.0.0-beta.0 <8",
-        "@jest/types": "^29.0.0",
-        "babel-jest": "^29.0.0",
-        "jest": "^29.0.0",
-        "typescript": ">=4.3 <6"
-      },
-      "peerDependenciesMeta": {
-        "@babel/core": {
-          "optional": true
-        },
-        "@jest/types": {
-          "optional": true
-        },
-        "babel-jest": {
-          "optional": true
-        },
-        "esbuild": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/ts-node": {
       "version": "10.9.1",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
@@ -35848,29 +35785,6 @@
         "@swc/wasm": {
           "optional": true
         }
-      }
-    },
-    "node_modules/tsconfig-paths": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
-      "integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
-      "dev": true,
-      "dependencies": {
-        "json5": "^2.2.2",
-        "minimist": "^1.2.6",
-        "strip-bom": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/tsconfig-paths/node_modules/strip-bom": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/tslib": {
@@ -36395,6 +36309,8 @@
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
       "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 4.0.0"
       }
@@ -36610,6 +36526,8 @@
       "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
       "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
@@ -36962,6 +36880,8 @@
       "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-4.0.0.tgz",
       "integrity": "sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "xml-name-validator": "^4.0.0"
       },
@@ -37438,6 +37358,8 @@
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
       "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "iconv-lite": "0.6.3"
       },
@@ -37450,6 +37372,8 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -37706,6 +37630,8 @@
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
       "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -37734,7 +37660,9 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/xss": {
       "version": "1.0.14",
@@ -38072,7 +38000,6 @@
         "zone.js": "~0.13.0"
       },
       "devDependencies": {
-        "@angular-builders/jest": "^16.0.0",
         "@angular-devkit/build-angular": "^16.0.5",
         "@angular/cli": "^16.0.5",
         "@angular/compiler-cli": "^16.0.5",

--- a/packages/portal/angular.json
+++ b/packages/portal/angular.json
@@ -23,11 +23,7 @@
             "polyfills": "src/polyfills.ts",
             "tsConfig": "tsconfig.app.json",
             "inlineStyleLanguage": "scss",
-            "assets": [
-              "src/favicon.ico",
-              "src/robots.txt",
-              "src/assets"
-            ],
+            "assets": ["src/favicon.ico", "src/robots.txt", "src/assets"],
             "styles": [
               "../../node_modules/@angular/material/prebuilt-themes/deeppurple-amber.css",
               "src/styles/styles.scss"
@@ -89,19 +85,10 @@
           }
         },
         "test": {
-          "builder": "@ngx-env/builder:karma",
+          "builder": "@angular-devkit/build-angular:jest",
           "options": {
             "tsConfig": "tsconfig.spec.json",
-            "assets": [
-              "src/favicon.ico",
-              "src/robots.txt",
-              "src/assets"
-            ],
-            "styles": [
-              "../../node_modules/@angular/material/prebuilt-themes/deeppurple-amber.css",
-              "src/styles/styles.scss"
-            ],
-            "scripts": []
+            "polyfills": ["zone.js", "zone.js/testing"]
           }
         }
       }

--- a/packages/portal/package.json
+++ b/packages/portal/package.json
@@ -31,7 +31,6 @@
     "zone.js": "~0.13.0"
   },
   "devDependencies": {
-    "@angular-builders/jest": "^16.0.0",
     "@angular-devkit/build-angular": "^16.0.5",
     "@angular/cli": "^16.0.5",
     "@angular/compiler-cli": "^16.0.5",

--- a/packages/portal/src/app/shared/guards/auth-guard.service.spec.ts
+++ b/packages/portal/src/app/shared/guards/auth-guard.service.spec.ts
@@ -1,21 +1,95 @@
-import { TestBed } from '@angular/core/testing';
-import { AuthGuard } from './auth-guard.service';
+import { provideLocationMocks } from "@angular/common/testing";
+import { Component, EnvironmentProviders, makeEnvironmentProviders, ValueProvider } from "@angular/core";
+import { TestBed } from "@angular/core/testing";
+import { provideRouter } from "@angular/router";
+import { RouterTestingHarness } from "@angular/router/testing";
+import { of } from "rxjs";
+import { UserRole, UserService } from "../user/user.service";
+import { canActiveAuthGuard } from "./auth-guard.service";
 
-global.fetch = jest.fn(() =>
-  Promise.resolve({
-    json: () => Promise.resolve({})
-  })
-) as any;
+@Component({
+  standalone: true,
+  template: "",
+})
+class DummyAuthenticationComponent {}
 
-describe('AuthGuard', () => {
-  let service: AuthGuard;
+@Component({
+  standalone: true,
+  template: "",
+})
+class DummyProfileComponent {}
 
-  beforeEach(() => {
-    TestBed.configureTestingModule({});
-    service = TestBed.inject(AuthGuard);
+function provideUserTesting(options: { userRole: UserRole }): EnvironmentProviders {
+  const guestUser: User = {
+    id: "guest",
+    name: "Guest",
+    photo: "account_circle",
+    role: UserRole.Guest,
+  };
+  const testUser: User = {
+    id: "be092a414817ff761949e046f4adf169",
+    name: "Test User",
+    photo: "account_circle",
+    role: options.userRole,
+    email: "testuser@example.com",
+    address: "fake address",
+    auth: {
+      provider: "github",
+      lastLogin: new Date().toISOString(),
+    },
+  };
+  const userServiceStub: Partial<UserService> = {
+    user$: of(options.userRole === UserRole.Guest ? guestUser : testUser),
+  };
+  const userServiceTestingProvider: ValueProvider = {
+    provide: UserService,
+    useValue: userServiceStub,
+  };
+
+  return makeEnvironmentProviders([userServiceTestingProvider]);
+}
+
+async function setup(options: { userRole: UserRole }) {
+  TestBed.configureTestingModule({
+    providers: [
+      provideUserTesting({ userRole: options.userRole }),
+      provideRouter([
+        {
+          path: "me",
+          canActivate: [canActiveAuthGuard],
+          component: DummyProfileComponent,
+        },
+        {
+          path: "auth/login",
+          component: DummyAuthenticationComponent,
+        },
+      ]),
+      provideLocationMocks(),
+    ],
+  });
+  const harness = await RouterTestingHarness.create();
+
+  return {
+    harness,
+  };
+}
+
+describe("canActiveAuthGuard", () => {
+  it("accepts renters", async () => {
+    const { harness } = await setup({ userRole: UserRole.Renter });
+
+    await harness.navigateByUrl("/me", DummyProfileComponent);
   });
 
-  it('should be created', () => {
-    expect(service).toBeTruthy();
+  it("accepts admins", async () => {
+    const { harness } = await setup({ userRole: UserRole.Admin });
+
+    await harness.navigateByUrl("/me", DummyProfileComponent);
+  });
+
+  it("rejects guests", async () => {
+    const { harness } = await setup({ userRole: UserRole.Guest });
+
+    await harness.navigateByUrl("/me", DummyAuthenticationComponent);
   });
 });


### PR DESCRIPTION
Fixes #226.

# Tests
- Implement tests for the functional route guard, `canActiveAuthGuard` to make the unit test suites pass

# Build
- Remove the unused `@angular-builders/jest` dependency
- Replace the ´@ngx-env/builder:karma` builder with the (experimental) `@angular-devkit/build-angular:jest` builder