### PR TITLE
fix: use container app secrets for credentials

### DIFF
--- a/infra/app/blog.bicep
+++ b/infra/app/blog.bicep
@@ -22,10 +22,16 @@ module app '../core/host/container-app.bicep' = {
     containerRegistryName: containerRegistryName
     containerCpuCoreCount: '1.0'
     containerMemory: '2.0Gi'
+    secrets: [
+      {
+        name: 'APPINSIGHTS_CS'
+        value: applicationInsights.properties.ConnectionString
+      }
+    ]
     env: [
       {
         name: 'APPLICATIONINSIGHTS_CONNECTION_STRING'
-        value: applicationInsights.properties.ConnectionString
+        value: 'secretref:APPINSIGHTS_CS'
       }
       {
         name: 'NEXT_PUBLIC_STRAPI_API_URL'

--- a/infra/app/cms.bicep
+++ b/infra/app/cms.bicep
@@ -34,14 +34,10 @@ module cms '../core/host/container-app.bicep' = {
     containerRegistryName: containerRegistryName
     containerCpuCoreCount: '1.0'
     containerMemory: '2.0Gi'
-    env: [
+    secrets: [
       {
-        name: 'APPLICATIONINSIGHTS_CONNECTION_STRING'
+        name: 'APPINSIGHTS_CS'
         value: applicationInsights.properties.ConnectionString
-      }
-      {
-        name: 'DATABASE_HOST'
-        value: databaseHost
       }
       {
         name: 'DATABASE_USERNAME'
@@ -50,10 +46,6 @@ module cms '../core/host/container-app.bicep' = {
       {
         name: 'DATABASE_PASSWORD'
         value: databasePassword
-      }
-      {
-        name: 'DATABASE_NAME'
-        value: databaseName
       }
       {
         name: 'JWT_SECRET'
@@ -72,6 +64,48 @@ module cms '../core/host/container-app.bicep' = {
         value: adminJwtSecret
       }
       {
+        name: 'STORAGE_ACCOUNT_KEY'
+        value: storageAccount.listKeys().keys[0].value
+      }
+    ]
+    env: [
+      {
+        name: 'APPLICATIONINSIGHTS_CONNECTION_STRING'
+        value: 'secretref:APPINSIGHTS_CS'
+      }
+      {
+        name: 'DATABASE_HOST'
+        value: databaseHost
+      }
+      {
+        name: 'DATABASE_USERNAME'
+        value: 'secretref:DATABASE_USERNAME'
+      }
+      {
+        name: 'DATABASE_PASSWORD'
+        value: 'secretref:DATABASE_PASSWORD'
+      }
+      {
+        name: 'DATABASE_NAME'
+        value: databaseName
+      }
+      {
+        name: 'JWT_SECRET'
+        value: 'secretref:JWT_SECRET'
+      }
+      {
+        name: 'APP_KEYS'
+        value: 'secretref:APP_KEYS'
+      }
+      {
+        name: 'API_TOKEN_SALT'
+        value: 'secretref:API_TOKEN_SALT'
+      }
+      {
+        name: 'ADMIN_JWT_SECRET'
+        value: 'secretref:ADMIN_JWT_SECRET'
+      }
+      {
         name: 'NODE_ENV'
         value: 'production'
       }
@@ -81,7 +115,7 @@ module cms '../core/host/container-app.bicep' = {
       }
       {
         name: 'STORAGE_ACCOUNT_KEY'
-        value: storageAccount.listKeys().keys[0].value
+        value: 'secretref:STORAGE_ACCOUNT_KEY'
       }
       {
         name: 'STORAGE_CONTAINER_NAME'

--- a/infra/app/stripe.bicep
+++ b/infra/app/stripe.bicep
@@ -27,10 +27,28 @@ module stripe '../core/host/container-app.bicep' = {
     containerRegistryName: containerRegistryName
     containerCpuCoreCount: '1.0'
     containerMemory: '2.0Gi'
+    secrets: [
+      {
+        name: 'APPINSIGHTS_CS'
+        value: applicationInsights.properties.ConnectionString
+      }
+      {
+        name: 'STRIPE_PUBLIC_KEY'
+        value: stripePublicKey
+      }
+      {
+        name: 'STRIPE_SECRET_KEY'
+        value: stripeSecretKey
+      }
+      {
+        name: 'STRIPE_WEBHOOK'
+        value: stripeWebhookSecret
+      }
+    ]
     env: [
       {
         name: 'APPLICATIONINSIGHTS_CONNECTION_STRING'
-        value: applicationInsights.properties.ConnectionString
+        value: 'secretref:APPINSIGHTS_CS'
       }
       {
         name: 'API_URL'
@@ -42,15 +60,15 @@ module stripe '../core/host/container-app.bicep' = {
       }
       {
         name: 'STRIPE_PUBLIC_KEY'
-        value: stripePublicKey
+        value: 'secretref:STRIPE_PUBLIC_KEY'
       }
       {
         name: 'STRIPE_SECRET_KEY'
-        value: stripeSecretKey
+        value: 'secretref:STRIPE_SECRET_KEY'
       }
       {
         name: 'STRIPE_WEBHOOK_SECRET'
-        value: stripeWebhookSecret
+        value: 'secretref:STRIPE_WEBHOOK'
       }
     ]
     imageName: !empty(stripeImageName) ? stripeImageName : 'nginx:latest'

--- a/infra/core/host/container-app.bicep
+++ b/infra/core/host/container-app.bicep
@@ -6,6 +6,7 @@ param containerAppsEnvironmentName string = ''
 param containerName string = 'main'
 param containerRegistryName string = ''
 param env array = []
+param secrets array = []
 param external bool = true
 param imageName string
 param keyVaultName string = ''
@@ -32,12 +33,12 @@ resource app 'Microsoft.App/containerApps@2022-03-01' = {
         targetPort: targetPort
         transport: 'auto'
       }
-      secrets: [
+      secrets: concat(secrets, [
         {
           name: 'registry-password'
           value: containerRegistry.listCredentials().passwords[0].value
         }
-      ]
+      ])
       registries: [
         {
           server: '${containerRegistry.name}.azurecr.io'


### PR DESCRIPTION
Use Container Apps secrets for credentials to avoid having plaintext credentials passed as environment variables.

Note: secrets keys are limited to 20 chars, so I had to change some names