### PR TITLE
fix: fixed #280 updated value to get directly from listing

### DIFF
--- a/packages/portal/src/app/shared/booking-form/booking-form.component.ts
+++ b/packages/portal/src/app/shared/booking-form/booking-form.component.ts
@@ -42,7 +42,7 @@ export class BookingFormComponent implements OnInit {
 
   capacityMapping: { [k: string]: string } = { "=1": "One guest", other: "# guests" };
   monthsMapping: { [k: string]: string } = { "=0": "0 month", "=1": "1 month", other: "# months" };
-  
+
   isGuest = signal(false);
   monthlyRentPrice = signal(0);
   monthlyRentPriceWithDiscount = signal(0);
@@ -90,7 +90,7 @@ export class BookingFormComponent implements OnInit {
       return;
     }
 
-    const rentPriceWithDiscount = this.monthlyRentPrice() * (1 - (parseInt(this.listing?.fees?.[4], 10) || 0) / 100);
+    const rentPriceWithDiscount = (Number(this.listing?.fees?.[3]) || 0) * (1 - (parseInt(this.listing?.fees?.[4], 10) || 0) / 100);
     this.monthlyRentPrice.set(Number(this.listing?.fees?.[4]) || 0);
     this.monthlyRentPriceWithDiscount.set(Math.max(0, rentPriceWithDiscount));
     this.currency_code = this.listing?.fees?.[5].substring(0, 3);


### PR DESCRIPTION
fix #280. Updated the Value 
`this.monthlyRent` to get value from listing. this results in accurate value even when page is loaded directly