### PR TITLE
fix: fix typo in reservations list

### DIFF
--- a/packages/portal/src/app/profile/profile.component.html
+++ b/packages/portal/src/app/profile/profile.component.html
@@ -86,7 +86,7 @@
                   <span [ngPlural]="reservation.guests">
                     <ng-template ngPluralCase="=1">guest</ng-template>
                     <ng-template ngPluralCase="other">guests</ng-template>
-                  </span>
+                  </span>)
                   <span class="reservation-status" [ngClass]="reservation.status">{{ reservation.status }}</span>
                 </div>
                 <div mat-line class="reservation-subtitle">


### PR DESCRIPTION
Fixes #283 by adding a missing `)` in the reservations list.

Note: the text is currently hidden because of the problems described in #242.