### PR TITLE
fix: fixed sign-in buttons change background color after reloading the page #279

### DIFF
--- a/packages/portal/src/app/authentication/authentication.component.html
+++ b/packages/portal/src/app/authentication/authentication.component.html
@@ -5,9 +5,10 @@
 
     <nav>
 
-      <a *ngFor="let provider of providers" mat-raised-button class="button btn__{{provider.id}}" [href]="loginWith(provider.id)">
+      <a *ngFor="let provider of providers" mat-raised-button id="{{provider.id}}" class="button btn__{{provider.id}}" [href]="loginWith(provider.id)">
         Sign in with {{ provider.name }}
       </a>
+
 
     </nav>
   </section>

--- a/packages/portal/src/app/authentication/authentication.component.scss
+++ b/packages/portal/src/app/authentication/authentication.component.scss
@@ -35,37 +35,37 @@ section {
   }
 }
 
-.btn__google {
+#google {
   background-color: #4285f4;
   color: #fff;
 }
 
-.btn__facebook {
+#facebook {
   background-color: #3b5998;
   color: #fff;
 }
 
-.btn__twitter {
+#twitter {
   background-color: #1da1f2;
   color: #fff;
 }
 
-.btn__github {
+#github {
   background-color: #333;
   color: #fff;
 }
 
-.btn__linkedin {
+#linkedin {
   background-color: #0077b5;
   color: #fff;
 }
 
-.btn__microsoft {
+#microsoft {
   background-color: #f65314;
   color: #fff;
 }
 
-.btn__apple {
+#apple {
   background-color: #000;
   color: #fff;
 }


### PR DESCRIPTION
Fixes #279 Regarding the Sign-In Button Bug

I attempted several approaches to resolve it, but I couldn't determine why the existing CSS was suddenly being overridden. While using `!important` would have been a quick solution, it's not considered a best practice. Instead, I enhanced the CSS styles by making them more specific, assigning unique IDs to each button, such as #google for the Google button, like so:

`<a *ngFor="let provider of providers" mat-raised-button id="{{provider.id}}" class="button btn__{{provider.id}}" [href]="loginWith(provider.id)">
  Sign in with {{ provider.name }}
</a>
`
If you have any concerns about the optimization and good practices, please feel free to provide guidance on alternative solutions.

If you find this approach suitable, I'm open to suggestions regarding other issues also I am open to other suggestions. :)


https://github.com/Azure-Samples/contoso-real-estate/assets/43810146/451d4d64-edc1-4c13-95bc-eedb19bbf3d2

@juliamuiruri4  
Also, do I have to anything else to make it count as my hack-together contribution?