### PR TITLE
fix: rename glob to globe

### DIFF
--- a/packages/portal/src/app/homepage/homepage.component.html
+++ b/packages/portal/src/app/homepage/homepage.component.html
@@ -7,7 +7,7 @@
 
   <p>
     The Contoso Portal is a place where you can find all the information you need to rent your next apartment or home.
-    We offer a wide variety of listings across the glob, so you can find the perfect place to call home.
+    We offer a wide variety of listings across the globe, so you can find the perfect place to call home.
   </p>
   <p class="stage__button">
     <a mat-flat-button color="primary" href="/search">Browse listings</a>


### PR DESCRIPTION
Fixes [#288](https://github.com/Azure-Samples/contoso-real-estate/issues/288) by adding an `e` to word `glob`.

## Screenshots
 
![Screenshot 2023-08-19 at 16 11 00](https://github.com/Azure-Samples/contoso-real-estate/assets/20414083/b811a095-740f-4ca3-958a-834cb8316207)
