### PR TITLE
fix: fixed prices mismatch on portal and booking pages

### DIFF
--- a/packages/portal/src/app/shared/booking-form/booking-form.component.ts
+++ b/packages/portal/src/app/shared/booking-form/booking-form.component.ts
@@ -91,7 +91,7 @@ export class BookingFormComponent implements OnInit {
     }
 
     const rentPriceWithDiscount = this.monthlyRentPrice() * (1 - (parseInt(this.listing?.fees?.[4], 10) || 0) / 100);
-    this.monthlyRentPrice.set(Number(this.listing?.fees?.[4]) || 0);
+    this.monthlyRentPrice.set(Number(this.listing?.fees?.[3]) || 0);
     this.monthlyRentPriceWithDiscount.set(Math.max(0, rentPriceWithDiscount));
     this.currency_code = this.listing?.fees?.[5].substring(0, 3);
     this.currency_symbol.set(this.listing?.fees?.[5].substring(4));


### PR DESCRIPTION
fixes #251

Updated prices on the booking page to match prices on the portal home page 
match `packages/portal/src/app/shared/card/card.component.ts`

Price on Portal Home Page
![image](https://github.com/Azure-Samples/contoso-real-estate/assets/64026625/ee76a13a-da21-4652-9277-8bb2dc9ca7c5)
Price on Booking Page
![image](https://github.com/Azure-Samples/contoso-real-estate/assets/64026625/377f1fa9-5804-4811-9ca8-e2827f645ee7)