### PR TITLE
feat: Create sharing menu

### DIFF
--- a/packages/docs/website/docs/02-develop/01-intro.md
+++ b/packages/docs/website/docs/02-develop/01-intro.md
@@ -50,4 +50,4 @@ In this tutorial, you'll create a serverless web application that  enables enter
 
 Contribute to the [reference implementation](https://github.com/Azure-Samples/contoso-real-estate) directly by opening a pull request or filing an issue on that repository. We would love to get your feedback on how you are re-implementing the reference architecture, or extending the reference implementation, in your own projects.
 
-Have feedback on this developer guide? Share your questions and comments via the relevant topic on our [Discussion Forum](https://github.com/contoso-real-estate/docs-website/discussions). Use this also to share your own insights or observations with community peers.
+Have feedback on this developer guide? Share your questions and comments via the relevant topic on our [Discussion Forum](https://github.com/Azure-Samples/contoso-real-estate/discussions). Use this also to share your own insights or observations with community peers.

--- a/packages/portal/src/app/rentalpage/rentalpage.component.html
+++ b/packages/portal/src/app/rentalpage/rentalpage.component.html
@@ -44,9 +44,20 @@
     <aside>
       <app-favorite-button *appHasRole="[userRole.Admin, userRole.Renter]" [listing]="listing()"></app-favorite-button>
 
-      <button (click)="share()" title="Share listing" class="bookmark-listing">
+      <button mat-icon-button [matMenuTriggerFor]="menu" aria-label="Example icon-button with a menu">
         <span aria-hidden="false" aria-label="Share listing" class="material-symbols-outlined"> share </span>
       </button>
+      <mat-menu #menu="matMenu">
+        <button mat-menu-item>
+          <span>Facebook</span>
+        </button>
+        <button mat-menu-item>
+          <span>Twitter</span>
+        </button>
+        <button mat-menu-item>
+          <span>Instagram</span>
+        </button>
+      </mat-menu>
     </aside>
   </section>
 

--- a/packages/portal/src/app/rentalpage/rentalpage.component.html
+++ b/packages/portal/src/app/rentalpage/rentalpage.component.html
@@ -44,18 +44,18 @@
     <aside>
       <app-favorite-button *appHasRole="[userRole.Admin, userRole.Renter]" [listing]="listing()"></app-favorite-button>
 
-      <button mat-icon-button [matMenuTriggerFor]="menu" aria-label="Example icon-button with a menu">
-        <span aria-hidden="false" aria-label="Share listing" class="material-symbols-outlined"> share </span>
+      <button mat-icon-button [matMenuTriggerFor]="menu" title="Share listing" aria-label="Share listing to social media">
+        <span aria-hidden="false" aria-label="Share listing to social media" class="material-symbols-outlined"> share </span>
       </button>
       <mat-menu #menu="matMenu">
-        <button mat-menu-item>
-          <span>Facebook</span>
+        <button mat-menu-item (click)="share()" title="Share listing to Facebook" class="bookmark-listing">
+          <span aria-hidden="false" aria-label="Share listing to Facebook">Facebook</span>
         </button>
-        <button mat-menu-item>
-          <span>Twitter</span>
+        <button mat-menu-item (click)="share()" title="Share listing to Twitter" class="bookmark-listing">
+          <span aria-hidden="false" aria-label="Share listing to Twitter">Twitter</span>
         </button>
-        <button mat-menu-item>
-          <span>Instagram</span>
+        <button mat-menu-item (click)="share()" title="Share listing to Instagram" class="bookmark-listing">
+          <span aria-hidden="false" aria-label="Share listing to Instagram">Instagram</span>
         </button>
       </mat-menu>
     </aside>

--- a/packages/portal/src/app/rentalpage/rentalpage.component.html
+++ b/packages/portal/src/app/rentalpage/rentalpage.component.html
@@ -48,13 +48,13 @@
         <span aria-hidden="false" aria-label="Share listing to social media" class="material-symbols-outlined"> share </span>
       </button>
       <mat-menu #menu="matMenu">
-        <button mat-menu-item (click)="share()" title="Share listing to Facebook" class="bookmark-listing">
+        <button mat-menu-item (click)="share('facebook')" title="Share listing to Facebook" class="bookmark-listing">
           <span aria-hidden="false" aria-label="Share listing to Facebook">Facebook</span>
         </button>
-        <button mat-menu-item (click)="share()" title="Share listing to Twitter" class="bookmark-listing">
+        <button mat-menu-item (click)="share('twitter')" title="Share listing to Twitter" class="bookmark-listing">
           <span aria-hidden="false" aria-label="Share listing to Twitter">Twitter</span>
         </button>
-        <button mat-menu-item (click)="share()" title="Share listing to Instagram" class="bookmark-listing">
+        <button mat-menu-item (click)="share('instagram')" title="Share listing to Instagram" class="bookmark-listing">
           <span aria-hidden="false" aria-label="Share listing to Instagram">Instagram</span>
         </button>
       </mat-menu>

--- a/packages/portal/src/app/rentalpage/rentalpage.component.html
+++ b/packages/portal/src/app/rentalpage/rentalpage.component.html
@@ -54,9 +54,6 @@
         <button mat-menu-item (click)="share('twitter')" title="Share listing to Twitter" class="bookmark-listing">
           <span aria-hidden="false" aria-label="Share listing to Twitter">Twitter</span>
         </button>
-        <button mat-menu-item (click)="share('instagram')" title="Share listing to Instagram" class="bookmark-listing">
-          <span aria-hidden="false" aria-label="Share listing to Instagram">Instagram</span>
-        </button>
       </mat-menu>
     </aside>
   </section>

--- a/packages/portal/src/app/rentalpage/rentalpage.component.html
+++ b/packages/portal/src/app/rentalpage/rentalpage.component.html
@@ -51,7 +51,7 @@
         <button mat-menu-item (click)="share('facebook')" title="Share listing to Facebook" class="bookmark-listing">
           <span aria-hidden="false" aria-label="Share listing to Facebook">Facebook</span>
         </button>
-        <button mat-menu-item (click)="share('twitter')" title="Share listing to Twitter" class="bookmark-listing">
+        <button mat-menu-item (click)="share('twitter')" title="Share listing to X (Formerly Twitter)" class="bookmark-listing">
           <span aria-hidden="false" aria-label="Share listing to Twitter">Twitter</span>
         </button>
       </mat-menu>

--- a/packages/portal/src/app/rentalpage/rentalpage.component.ts
+++ b/packages/portal/src/app/rentalpage/rentalpage.component.ts
@@ -1,7 +1,7 @@
 import { CommonModule } from "@angular/common";
 import { Component, OnInit, inject, signal } from "@angular/core";
 import { ActivatedRoute, Navigation, Router } from "@angular/router";
-import {MatMenuModule} from '@angular/material/menu';
+import { MatMenuModule } from "@angular/material/menu";
 import { BookingFormComponent } from "../shared/booking-form/booking-form.component";
 import { FavoriteButtonComponent } from "../shared/favorite-button/favorite-button/favorite-button.component";
 import { HasRoleDirective } from "../shared/has-role/has-role.directive";

--- a/packages/portal/src/app/rentalpage/rentalpage.component.ts
+++ b/packages/portal/src/app/rentalpage/rentalpage.component.ts
@@ -1,6 +1,7 @@
 import { CommonModule } from "@angular/common";
 import { Component, OnInit, inject, signal } from "@angular/core";
 import { ActivatedRoute, Navigation, Router } from "@angular/router";
+import {MatMenuModule} from '@angular/material/menu';
 import { BookingFormComponent } from "../shared/booking-form/booking-form.component";
 import { FavoriteButtonComponent } from "../shared/favorite-button/favorite-button/favorite-button.component";
 import { HasRoleDirective } from "../shared/has-role/has-role.directive";
@@ -13,7 +14,7 @@ import { UserRole, UserService } from "../shared/user/user.service";
   templateUrl: "./rentalpage.component.html",
   styleUrls: ["./rentalpage.component.scss"],
   standalone: true,
-  imports: [CommonModule, ListingDetailComponent, BookingFormComponent, HasRoleDirective, FavoriteButtonComponent],
+  imports: [CommonModule, ListingDetailComponent, BookingFormComponent, HasRoleDirective, FavoriteButtonComponent, MatMenuModule],
 })
 export class RentalpageComponent implements OnInit {
   userRole: typeof UserRole = UserRole;

--- a/packages/portal/src/app/rentalpage/rentalpage.component.ts
+++ b/packages/portal/src/app/rentalpage/rentalpage.component.ts
@@ -58,8 +58,8 @@ export class RentalpageComponent implements OnInit {
       .map((x, i) => (i < this.listing().reviews_stars ? 1 : 0)));
   }
 
-  async share() {
-    await this.listingService.share(this.listing());
+  async share(platform: string) {
+    await this.listingService.share(platform, this.listing());
   }
 
   async onRent(reservationDetails: ReservationRequest) {

--- a/packages/portal/src/app/shared/listing.service.ts
+++ b/packages/portal/src/app/shared/listing.service.ts
@@ -42,7 +42,7 @@ export class ListingService {
   async share(platform: string, listing: Listing) {
     const rent = listing.fees.at(0);
     const currency = listing.fees.at(-1);
-    if (platform === "facebook"){
+    if (platform && platform === "facebook"){
       this.windowService
         .nativeWindow()
         .open(
@@ -51,7 +51,7 @@ export class ListingService {
           )}+on+Contoso+Rental+at+${currency}${rent}/month` + `&u=`+ window.location.href,
         );
     }
-    else if (platform === "twitter"){
+    else if (platform && platform === "twitter"){
       this.windowService
       .nativeWindow()
       .open(

--- a/packages/portal/src/app/shared/listing.service.ts
+++ b/packages/portal/src/app/shared/listing.service.ts
@@ -42,7 +42,7 @@ export class ListingService {
   async share(platform: string, listing: Listing) {
     const rent = listing.fees.at(0);
     const currency = listing.fees.at(-1);
-    if(platform === "facebook"){
+    if (platform === "facebook"){
       this.windowService
         .nativeWindow()
         .open(
@@ -51,7 +51,7 @@ export class ListingService {
           )}+on+Contoso+Rental+at+${currency}${rent}/month` + `&u=`+ window.location.href,
         );
     }
-    else if(platform === "twitter"){
+    else if (platform === "twitter"){
       this.windowService
       .nativeWindow()
       .open(

--- a/packages/portal/src/app/shared/listing.service.ts
+++ b/packages/portal/src/app/shared/listing.service.ts
@@ -48,7 +48,7 @@ export class ListingService {
         .open(
           `http://twitter.com/share?text=Checkout+this+cool+apartment+I+found+in+${listing.address.at(
             4,
-          )}+on+Contoso+Rental+at+${currency}${rent}/month` + `&hashtags=#renting+#apartment`,
+          )}+on+Contoso+Rental+at+${currency}${rent}/month` + `&hashtags=renting,apartment`,
         );
     }
     else if(platform === "twitter"){
@@ -57,7 +57,7 @@ export class ListingService {
       .open(
         `http://twitter.com/share?text=Checkout+this+cool+apartment+I+found+in+${listing.address.at(
           4,
-        )}+on+Contoso+Rental+at+${currency}${rent}/month` + `&hashtags=#renting+#apartment`,
+        )}+on+Contoso+Rental+at+${currency}${rent}/month` + `&hashtags=renting,apartment`,
       );
     }
     else if(platform === "instagram"){
@@ -66,7 +66,7 @@ export class ListingService {
       .open(
         `http://twitter.com/share?text=Checkout+this+cool+apartment+I+found+in+${listing.address.at(
           4,
-        )}+on+Contoso+Rental+at+${currency}${rent}/month` + `&hashtags=#renting+#apartment`,
+        )}+on+Contoso+Rental+at+${currency}${rent}/month` + `&hashtags=renting,apartment`,
       );
     }
   }

--- a/packages/portal/src/app/shared/listing.service.ts
+++ b/packages/portal/src/app/shared/listing.service.ts
@@ -42,23 +42,27 @@ export class ListingService {
   async share(platform: string, listing: Listing) {
     const rent = listing.fees.at(0);
     const currency = listing.fees.at(-1);
+    const currentWindowUrl = window.location.href;
+    const socialMediaUrls = {
+      twitter : `http://twitter.com/share?text=Checkout+this+cool+apartment+I+found+in+${listing.address.at(
+        4,
+      )}+on+Contoso+Rental+at+${currency}${rent}/month` + `&url=` + currentWindowUrl + `&hashtags=renting,apartment`,
+      facebook : `https://www.facebook.com/sharer/sharer.php?title=Checkout+this+cool+apartment+I+found+in+${listing.address.at(
+        4,
+      )}+on+Contoso+Rental+at+${currency}${rent}/month` + `&u=` + currentWindowUrl,
+    };
+    const { twitter, facebook } = socialMediaUrls;
     if (platform && platform === "facebook"){
+      const shareUrl = facebook;
       this.windowService
         .nativeWindow()
-        .open(
-          `https://www.facebook.com/sharer/sharer.php?title=Checkout+this+cool+apartment+I+found+in+${listing.address.at(
-            4,
-          )}+on+Contoso+Rental+at+${currency}${rent}/month` + `&u=`+ window.location.href,
-        );
+        .open(shareUrl);
     }
     else if (platform && platform === "twitter"){
+      const shareUrl = twitter;
       this.windowService
       .nativeWindow()
-      .open(
-        `http://twitter.com/share?text=Checkout+this+cool+apartment+I+found+in+${listing.address.at(
-          4,
-        )}+on+Contoso+Rental+at+${currency}${rent}/month`+ `&url=`+ window.location.href + `&hashtags=renting,apartment`,
-      );
+      .open(shareUrl);
     }
   }
 

--- a/packages/portal/src/app/shared/listing.service.ts
+++ b/packages/portal/src/app/shared/listing.service.ts
@@ -6,7 +6,7 @@ import { WindowService } from "../core/window/window.service";
 })
 export class ListingService {
   private windowService = inject(WindowService);
-  
+
   async getListings({ limit = 10, offset = 0 } = {}): Promise<Listing[]> {
     const resource = await fetch(`/api/listings?limit=${limit}&offset=${offset}`).then(response => {
       if (response.status === 200) {
@@ -39,16 +39,36 @@ export class ListingService {
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  async share(listing: Listing) {
+  async share(platform: string, listing: Listing) {
     const rent = listing.fees.at(0);
     const currency = listing.fees.at(-1);
-    this.windowService
+    if(platform === "facebook"){
+      this.windowService
+        .nativeWindow()
+        .open(
+          `http://twitter.com/share?text=Checkout+this+cool+apartment+I+found+in+${listing.address.at(
+            4,
+          )}+on+Contoso+Rental+at+${currency}${rent}/month` + `&hashtags=#renting+#apartment`,
+        );
+    }
+    else if(platform === "twitter"){
+      this.windowService
       .nativeWindow()
       .open(
         `http://twitter.com/share?text=Checkout+this+cool+apartment+I+found+in+${listing.address.at(
           4,
         )}+on+Contoso+Rental+at+${currency}${rent}/month` + `&hashtags=#renting+#apartment`,
       );
+    }
+    else if(platform === "instagram"){
+      this.windowService
+      .nativeWindow()
+      .open(
+        `http://twitter.com/share?text=Checkout+this+cool+apartment+I+found+in+${listing.address.at(
+          4,
+        )}+on+Contoso+Rental+at+${currency}${rent}/month` + `&hashtags=#renting+#apartment`,
+      );
+    }
   }
 
   async reserve(reservationDetails: ReservationRequest): Promise<CheckoutSession> {

--- a/packages/portal/src/app/shared/listing.service.ts
+++ b/packages/portal/src/app/shared/listing.service.ts
@@ -46,9 +46,9 @@ export class ListingService {
       this.windowService
         .nativeWindow()
         .open(
-          `http://twitter.com/share?text=Checkout+this+cool+apartment+I+found+in+${listing.address.at(
+          `https://www.facebook.com/sharer/sharer.php?title=Checkout+this+cool+apartment+I+found+in+${listing.address.at(
             4,
-          )}+on+Contoso+Rental+at+${currency}${rent}/month` + `&hashtags=renting,apartment`,
+          )}+on+Contoso+Rental+at+${currency}${rent}/month` + `&u=`+ window.location.href,
         );
     }
     else if(platform === "twitter"){
@@ -57,16 +57,7 @@ export class ListingService {
       .open(
         `http://twitter.com/share?text=Checkout+this+cool+apartment+I+found+in+${listing.address.at(
           4,
-        )}+on+Contoso+Rental+at+${currency}${rent}/month` + `&hashtags=renting,apartment`,
-      );
-    }
-    else if(platform === "instagram"){
-      this.windowService
-      .nativeWindow()
-      .open(
-        `http://twitter.com/share?text=Checkout+this+cool+apartment+I+found+in+${listing.address.at(
-          4,
-        )}+on+Contoso+Rental+at+${currency}${rent}/month` + `&hashtags=renting,apartment`,
+        )}+on+Contoso+Rental+at+${currency}${rent}/month`+ `&url=`+ window.location.href + `&hashtags=renting,apartment`,
       );
     }
   }


### PR DESCRIPTION
closes #255 
- Import Material Menu Library.
- Replaced sharing button with sharing Menu.
- Added a string parameter to track the clicked button.
- Redefined Sharing Function.
- Included if statements to check the clicked button and configure sharing accordingly.

While working on this I found a new issue the hashtags weren't added correctly to the twitter sharing link.
I fixed this issue now if you try to share on twitter the hashtags will appear.

Adding more platforms now will be much easier as it's only a copy-and-paste process. (see [this](https://dev.to/shahednasser/how-to-easily-add-share-links-for-each-social-media-platform-1l4f))
![image](https://github.com/Azure-Samples/contoso-real-estate/assets/64026625/c69b39e8-55fc-4c92-ae3e-5460d97ff961)