### PR TITLE
fix(API): local .env

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -62,7 +62,7 @@ To test payments, you can use the [Stripe test cards](https://stripe.com/docs/te
 To develop the Azure Functions app with the Azure databases, use the following steps.
 
 1. Fork the repository and open in Codespaces or Visual Studio dev container.
-1. In a terminal at the root of the repository, use a terminal to login to Azure Developer CLI. Complete the steps.
+1. At the root of the repository, use a terminal to login to Azure Developer CLI. Complete the steps.
 
   ```bash
   azd auth login

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -89,5 +89,5 @@ To develop the Azure Functions app with the Azure databases, use the following s
 1. Run the Functions app.
 
   ```bash
-  npm run start
+  npm start
   ```

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -80,7 +80,7 @@ To develop the Azure Functions app with the Azure databases, use the following s
   npm install
   ```
 
-1. In a terminal at the `./packages/API` subfolder, create an `.env.local` file for the Azure Functions app. This creates an environment file with Azure resource values.
+1. In a terminal at the `./packages/api` subfolder, create an `.env.local` file for the Azure Functions app. This creates an environment file with Azure resource values.
 
   ```bash
   npm run env

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -17,17 +17,31 @@ If you want to run the API independently and locally, the following technologies
 
 ## Steps to start the API
 
-1. fork or clone the repository locally
-2. assuming you are in the folder containing your clone, go to the terminal and run
+Complete the following steps **after provisioning the Azure resources** in order to develop and debug against Azure resources.
 
-```bash
-cd packages/api && npm install
-```
-Now you have all the dependencies installed for the API and can run
+1. Fork or clone the repository locally
+2. Provision Azure resources. 
 
-```bash
-npm start
-```
+  ```bash
+  azd auth login
+  azd provision
+  ```
+3. Assuming you are in the folder containing your clone, go to the terminal and run
+
+  ```bash
+  cd packages/api && npm install
+  ```
+4. Now you have all the dependencies installed for the API and can run
+
+  ```bash
+  npm start
+  ```
+
+5. Copy the provisioned environment file, `./.azure/YOUR-ENV/.env`, to this package.
+
+  ```bash
+  npm run env
+  ```
 
 ## Stripe API integration
 

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -17,31 +17,17 @@ If you want to run the API independently and locally, the following technologies
 
 ## Steps to start the API
 
-Complete the following steps **after provisioning the Azure resources** in order to develop and debug against Azure resources.
+1. fork or clone the repository locally
+2. assuming you are in the folder containing your clone, go to the terminal and run
 
-1. Fork or clone the repository locally
-2. Provision Azure resources. 
+```bash
+cd packages/api && npm install
+```
+Now you have all the dependencies installed for the API and can run
 
-  ```bash
-  azd auth login
-  azd provision
-  ```
-3. Assuming you are in the folder containing your clone, go to the terminal and run
-
-  ```bash
-  cd packages/api && npm install
-  ```
-4. Now you have all the dependencies installed for the API and can run
-
-  ```bash
-  npm start
-  ```
-
-5. Copy the provisioned environment file, `./.azure/YOUR-ENV/.env`, to this package.
-
-  ```bash
-  npm run env
-  ```
+```bash
+npm start
+```
 
 ## Stripe API integration
 
@@ -70,3 +56,38 @@ stripe trigger payment_intent.succeeded
 ```
 
 To test payments, you can use the [Stripe test cards](https://stripe.com/docs/testing#cards).
+
+## Local development with Azure resources
+
+To develop the Azure Functions app with the Azure databases, use the following steps.
+
+1. Fork the repository and open in Codespaces or Visual Studio dev container.
+1. In a terminal at the root of the repository, use a terminal to login to Azure Developer CLI. Complete the steps.
+
+  ```bash
+  azd auth login
+  ```
+
+1. Provision your Azure resources which also creates your local environment file with secrets and configurations.
+
+  ```bash
+  azd provision
+  ```
+
+1. Install the project dependencies.
+
+  ```bash
+  npm install
+  ```
+
+1. In a terminal at the `./packages/API` subfolder, create an `.env.local` file for the Azure Functions app. This creates an environment file with Azure resource values.
+
+  ```bash
+  npm run env
+  ```
+
+1. Run the Functions app.
+
+  ```bash
+  npm run start
+  ```

--- a/packages/api/config/index.ts
+++ b/packages/api/config/index.ts
@@ -18,7 +18,7 @@ export const getConfig: () => Promise<AppConfig> = async () => {
   // Load any ENV vars from local .env.local file
   if (process.env.NODE_ENV !== "production") {
     console.warn("Loading environment variables from root '.env.local' file. THIS SHOULD NOT BE USED IN PRODUCTION!");
-    dotenv.config({ path: path.resolve(process.cwd(), ".env.local") });
+    dotenv.config({ path: path.resolve(process.cwd(), "../../.env.local") });
   }
 
   await populateEnvironmentFromKeyVault();

--- a/packages/api/config/index.ts
+++ b/packages/api/config/index.ts
@@ -18,7 +18,7 @@ export const getConfig: () => Promise<AppConfig> = async () => {
   // Load any ENV vars from local .env.local file
   if (process.env.NODE_ENV !== "production") {
     console.warn("Loading environment variables from root '.env.local' file. THIS SHOULD NOT BE USED IN PRODUCTION!");
-    dotenv.config({ path: path.resolve(process.cwd(), "../../.env.local") });
+    dotenv.config({ path: path.resolve(process.cwd(), ".env.local") });
   }
 
   await populateEnvironmentFromKeyVault();

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "",
   "scripts": {
-    "env": "azd env get-values --no-prompt > .env",
+    "env": "azd env get-values --no-prompt > .env.local",
     "build": "tsc",
     "watch": "tsc --w",
     "prestart": "tsc && func extensions install",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "",
   "scripts": {
-    "env": "azd env get-values --no-prompt > .env.local",
+    "env": "azd env get-values --no-prompt > ../../.env.local",
     "build": "tsc",
     "watch": "tsc --w",
     "prestart": "tsc && func extensions install",


### PR DESCRIPTION
#343

1) Readme changes to help developer run API locally against Azure
2) package.json - change env file name to match code
3) config/index.ts - change code to match location of .env.local file


This change can go in before @glaucia86 migration to v4pm
