### PR TITLE
fix(scripts): db restore error when ran locally

### DIFF
--- a/scripts/database/restore.sh
+++ b/scripts/database/restore.sh
@@ -70,11 +70,6 @@ PGPASSWORD="$STRAPI_DATABASE_PASSWORD" pg_restore -v \
   --dbname="$STRAPI_DATABASE_NAME" \
   "$file" || true
 
-if [[ $? -ne 0 ]]; then
-  echo "!!Failed to restore PostgreSQL Database"
-  exit 1
-fi
-
 echo "PostgreSQL Database restored successfully"
 
 if [[ "$AZD_INSTALLED" == "true" ]]; then


### PR DESCRIPTION
Error during DB restore should not be caught, as when run locally on the try it tries to restore it will fail, which is expected.
On deployment a var is set so it won't occur.