### PR TITLE
fix(portal): remove twitter social provider #377

### DIFF
--- a/packages/api/models/user.schema.ts
+++ b/packages/api/models/user.schema.ts
@@ -14,7 +14,7 @@ export interface User {
   };
   email: string;
   auth: {
-    provider: "aad" | "apple" | "twitter" | "google" | "facebook";
+    provider: "aad" | "apple" | "google" | "facebook";
     token: string;
     lastLogin: number;
   };
@@ -61,7 +61,7 @@ const UserSchema = new Schema<User>({
     provider: {
       type: String,
       required: true,
-      enum: ["aad", "github", "twitter", "google", "facebook"],
+      enum: ["aad", "github", "google", "facebook"],
     },
     token: {
       type: String,

--- a/packages/docs/website/docs/02-develop/scenario-3/0-intro.md
+++ b/packages/docs/website/docs/02-develop/scenario-3/0-intro.md
@@ -41,7 +41,6 @@ The Static Web Apps in-built authentication mechanism is enabled for the applica
 | Microsoft Identity Platform | `/.auth/login/aad` | [App Service Microsoft Identity Platform login](https://docs.microsoft.com/azure/static-web-apps/authentication-authorization#app-service-microsoft-identity-platform-login) |
 | Facebook | `/.auth/login/facebook` | [App Service Facebook login](https://docs.microsoft.com/azure/static-web-apps/authentication-authorization#app-service-facebook-login) |
 | Google | `/.auth/login/google` | [App Service Google login](https://docs.microsoft.com/azure/static-web-apps/authentication-authorization#app-service-google-login) |
-| Twitter | `/.auth/login/twitter` | [App Service Twitter login](https://docs.microsoft.com/azure/static-web-apps/authentication-authorization#app-service-twitter-login) |
 | GitHub | `/.auth/login/github` | [App Service GitHub login](https://docs.microsoft.com/azure/static-web-apps/authentication-authorization#app-service-github-login) |
 | Sign in with Apple | `/.auth/login/apple` | [App Service Sign in With Apple login (Preview)](https://docs.microsoft.com/azure/static-web-apps/authentication-authorization#app-service-sign-in-with-apple-login-preview) |
 

--- a/packages/docs/website/docs/02-develop/scenario-3/1-federated.md
+++ b/packages/docs/website/docs/02-develop/scenario-3/1-federated.md
@@ -10,7 +10,6 @@ In our case, we will use a pre-configured provider. You can enable your required
 
 - Azure Active Directory
 - GitHub
-- Twitter
 
 In this document, we will use GitHub as the provider.
 

--- a/packages/portal/src/app/authentication/authentication.component.scss
+++ b/packages/portal/src/app/authentication/authentication.component.scss
@@ -56,11 +56,6 @@ section {
   color: #fff;
 }
 
-.button.btn__twitter {
-  background-color: #1da1f2;
-  color: #fff;
-}
-
 .button.btn__github {
   background-color: #333;
   color: #fff;

--- a/packages/portal/src/app/authentication/authentication.component.ts
+++ b/packages/portal/src/app/authentication/authentication.component.ts
@@ -10,7 +10,7 @@ import { Router } from "@angular/router";
 import { AuthService } from "../shared/authentication/auth.service";
 import { TextBlockComponent } from "../shared/text-block/text-block.component";
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
-import { faApple, faFacebook, faGithub, faGoogle, faMicrosoft, faTwitter } from "@fortawesome/free-brands-svg-icons";
+import { faApple, faFacebook, faGithub, faGoogle, faMicrosoft } from "@fortawesome/free-brands-svg-icons";
 
 @Component({
   selector: "app-authentication",
@@ -37,7 +37,6 @@ export class AuthenticationComponent implements OnInit {
     { name: "Microsoft", id: "microsoft", icon: faMicrosoft },
     { name: "Facebook", id: "facebook", icon: faFacebook },
     { name: "Google", id: "google", icon: faGoogle },
-    { name: "Twitter", id: "twitter", icon: faTwitter },
     { name: "GitHub", id: "github", icon: faGithub },
     { name: "Apple", id: "apple", icon: faApple }
   ];

--- a/packages/portal/src/types/index.d.ts
+++ b/packages/portal/src/types/index.d.ts
@@ -19,7 +19,7 @@ declare interface UserClientPrincipal {
   identityProvider: string;
 }
 
-declare type AuthProvider = "aad" | "github" | "twitter" | "google" | "facebook";
+declare type AuthProvider = "aad" | "github" | "google" | "facebook";
 declare type UserRole = "guest" | "renter" | "admin";
 
 declare interface Listing {


### PR DESCRIPTION
#377 - Twitter is no longer supported in list of social auth from SWA. It would need to be a customer provider to work so removing until that work is prioritized. 