### PR TITLE
Fix(api): revert cloud build to api

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "concurrently npm:start:* --kill-others",
     "start:services": "docker compose up",
-    "start:api": "npm run start --workspace=api-v4",
+    "start:api": "npm run start --workspace=api",
     "start:website": "npm run start:swa --workspace=portal",
     "test": "npm run test -ws --if-present",
     "build": "npm run build -ws --if-present",


### PR DESCRIPTION
@glaucia86 and I discussed rolling back the root package.json file to api v3 until entire deployment pipeline (and the conflicting version of azure-functions-core-tools) is figured out #386. This is a stopgap and will be returned to v4 in another PR. 