### PR TITLE
fix: post-create-command

### DIFF
--- a/.devcontainer/post-create-command.sh
+++ b/.devcontainer/post-create-command.sh
@@ -3,9 +3,8 @@
 sudo apt update
 npm i -g npm@latest fuzz-run
 
-# https://github.com/microsoft/playwright/issues/28331
-npx playwright install --with-deps
-
 # Install monorepo dependencies
 npm install
 
+# https://github.com/microsoft/playwright/issues/28331
+npx playwright install --with-deps


### PR DESCRIPTION
`npx playwright install`  needs to be after `npm install` otherwise there is no `playwright` bin record yet.